### PR TITLE
newrelic_rpm is not required on development environment

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -44,6 +44,6 @@ Padrino.after_load do
   DataMapper.finalize
 end
 
-require 'newrelic_rpm'
+require 'newrelic_rpm' if Padrino.env == :production
 
 Padrino.load!


### PR DESCRIPTION
I added condition not to include newrelic_rpm gem on
development env
