### PR TITLE
Trello #42 - Fix for bug when there's a single solution

### DIFF
--- a/models/account.rb
+++ b/models/account.rb
@@ -78,15 +78,18 @@ class Account
   end
 
   def status_for_assignment(assignment)
-    solutions = Solution.find_by_account_and_assignment(self, assignment)        
+    solutions = Solution.find_by_account_and_assignment(self, assignment) || []
+    if !solutions.respond_to?(:count)
+      solutions = [ solutions ]
+    end
+
     assignment_status = AssignmentStatus.new 
     assignment_status.assignment_id = assignment.id
     assignment_status.name = assignment.name
     assignment_status.deadline = assignment.deadline
-    if solutions.nil?
+    if solutions.empty?
       assignment_status.status = :solution_pending 
       assignment_status.solution_count = 0
-      #assignment_status.latest_solution_date = nil
       return assignment_status
     end
     solutions.sort_by! { |s| s.created_at}

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -43,13 +43,23 @@ describe Account do
 				student.status_for_assignment(assignment).solution_count.should eq 0
 			end
 
-			it 'should return the count of solutions submitted by the student for that assignment' do
-				course = Course.new( :name => "AlgoIII", :active => true )
+			it 'should return 1 when there is a single solution submitted' do
+			  course = Course.new( :name => "AlgoIII", :active => true )
 				student = Account.new( :email => "x@x.com", :role => "student", :buid => "?")
 				assignment = Assignment.new( :course => course )
 				solution = Solution.new( :assignment => assignment )
-				Solution.should_receive(:find_by_account_and_assignment).and_return([solution])
+				Solution.should_receive(:find_by_account_and_assignment).and_return(solution)
 				student.status_for_assignment(assignment).solution_count.should eq 1
+			end
+
+			it 'should return the count of multiple solutions submitted by the student for that assignment' do
+				course = Course.new( :name => "AlgoIII", :active => true )
+				student = Account.new( :email => "x@x.com", :role => "student", :buid => "?")
+				assignment = Assignment.new( :course => course )
+				solution1 = Solution.new( :assignment => assignment, :account => student )
+				solution2 = Solution.new( :assignment => assignment, :account => student )
+				Solution.should_receive(:find_by_account_and_assignment).and_return([ solution1, solution2 ])
+				student.status_for_assignment(assignment).solution_count.should eq 2
 			end
 
 		end


### PR DESCRIPTION
If there's a single solution associated to the account and the
assignment, the method Solution.find_by_account_and_assignment returns a
single instance of Solution instead of an array of 1 element. Updated
code to work on that scenario.
