### PR TITLE
Footer centrado

### DIFF
--- a/public/stylesheets/alfred.css
+++ b/public/stylesheets/alfred.css
@@ -7,7 +7,7 @@ section#main-content {
 
 footer {
     margin-bottom: 20px;
-    text-align: right;
+    text-align: center;
 }
 
 .centered {


### PR DESCRIPTION
Hay un `text-align: right` muy raro en el footer:

![Screenshot](http://i.imgur.com/0lQtT7H.png)

no quedaría mejor con el texto centrado?